### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install flake8
+      - run: flake8 start_servers.py
+      - run: python -m py_compile start_servers.py
+      - run: docker build -t mcp-orchestrator .


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run flake8, compile check, and build Dockerfile

## Testing
- `python -m py_compile start_servers.py`
- `flake8 start_servers.py` *(fails: `bash: flake8: command not found`)*
- `docker build -t mcp-orchestrator .` *(fails: `Cannot connect to the Docker daemon`)*